### PR TITLE
Remove python39 until pylint is ready

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,7 @@ setup(
     packages=find_packages(),
     install_requires=[],
     extras_require={
-        "dev": [
-            "black==20.8b1",
-            "pre-commit==2.9.3",
-            "pylint==2.6.0",
-            "mypy==0.790",
-        ]
+        "dev": ["black==20.8b1", "pre-commit==2.9.3", "pylint==2.6.0", "mypy==0.790"]
     },
     include_package_data=True,
     package_data={"blokus": ["../README.md", "../LICENSE.md", "../MANIFEST.in"]},
@@ -39,7 +34,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
     ],
     test_suite="tests",
     zip_safe=False,


### PR DESCRIPTION
Pylint has trouble with old-style typing syntax in Python 3.9. Remove it from the CI checks and from `setup.py` until it has been updated to accommodate Python 3.9.